### PR TITLE
Fixed error when running database setup

### DIFF
--- a/app/models/member.rb
+++ b/app/models/member.rb
@@ -1,3 +1,5 @@
+# encoding: UTF-8
+
 class Member < ActiveRecord::Base
   ENTITIES = ActiveSupport::OrderedHash[[
     ['company',    'Company'],


### PR DESCRIPTION
Added # encoding: UTF-8 to the member model to avoid the invalid multibyte char (US-ASCII) error when running db:setup
